### PR TITLE
Update cryptograpy version used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules"]
 packages = [{include = "satispaython", from="src"}]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-cryptography = "^3.4"
-httpx = "^0.18"
+python = "^3.8"
+cryptography = "^46.0.7"
+httpx = "^0.25"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.10"
@@ -42,13 +42,13 @@ source = ["src/satispaython", ".tox/py*/lib/python*/site-packages/satispaython"]
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = clean,py36,py37,py38,py39,report
+envlist = clean,py38,py39,report
 
 [testenv]
-setenv = py{36,37,38,39}: COVERAGE_FILE=.coverage.{envname}
+setenv = py{38,39}: COVERAGE_FILE=.coverage.{envname}
 depends =
-    {py36,py37,py38,py39}: clean
-    report: py36,py37,py38,py39
+    {py38,py39}: clean
+    report: py38,py39
 deps =
     pytest-cov
     pytest-freezegun

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "satispaython"
-version = "0.4.0"
+version = "1.0.0"
 description = "A simple library to manage Satispay payments following the Web-button flow."
 license = "MIT"
 authors = ["Daniele Pira <daniele.pira@otto.to.it>"]

--- a/src/satispaython/client.py
+++ b/src/satispaython/client.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
@@ -34,7 +35,7 @@ class SatispayClient(Client):
             body_params.update({'flow': 'MATCH_CODE', 'amount_unit': amount_unit, 'currency': currency})
         except AttributeError:
             body_params = {'flow': 'MATCH_CODE', 'amount_unit': amount_unit, 'currency': currency}
-        return self.post(target, json=body_params, headers=headers)
+        return self.post(target, content=json.dumps(body_params).encode(), headers=headers)
 
     def get_payment_details(self, payment_id: str, headers: Optional[Headers] = None) -> Response:
         target = URL(f'/g_business/v1/payments/{payment_id}')
@@ -69,7 +70,7 @@ class AsyncSatispayClient(AsyncClient):
             body_params.update({'flow': 'MATCH_CODE', 'amount_unit': amount_unit, 'currency': currency})
         except AttributeError:
             body_params = {'flow': 'MATCH_CODE', 'amount_unit': amount_unit, 'currency': currency}
-        return await self.post(target, json=body_params, headers=headers)
+        return await self.post(target, content=json.dumps(body_params).encode(), headers=headers)
 
     async def get_payment_details(self, payment_id: str, headers: Optional[Headers] = None) -> Response:
         target = URL(f'/g_business/v1/payments/{payment_id}')


### PR DESCRIPTION
1. pyproject.toml: Updated cryptography from ^3.4 to ^46.0.7, updated python from ^3.6 to ^3.8 (cryptography 42+ dropped Python 3.6/3.7), updated httpx from ^0.18 to ^0.25 (respx 0.23.1 requires httpx ≥0.25).
2. src/satispaython/client.py: Replaced json=body_params with content=json.dumps(body_params).encode() in both SatispayClient and AsyncSatispayClient. httpx 0.23+ switched to compact JSON serialization ({'key':'val'}) whereas the digest signatures in the tests were computed using Python's standard json.dumps format ({'key': 'val'}). By serializing manually we control the output format.

3. [BREAKING CHANGE] Drop python 3.6 and 3.7 support as cryptography 42+ dropped Python 3.6/3.7